### PR TITLE
time: fix struct tm for Solaris / Illumos

### DIFF
--- a/vlib/time/time_nix.v
+++ b/vlib/time/time_nix.v
@@ -10,7 +10,6 @@ struct C.tm {
 	tm_hour int
 	tm_min  int
 	tm_sec  int
-	tm_gmtoff int // seconds
 }
 
 fn C.timegm(&tm) time_t


### PR DESCRIPTION
Remove the member variable `tm_gmtoff` as it is not used and not present on Solaris.


<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
